### PR TITLE
fix/async-connect

### DIFF
--- a/packages/kit/src/components/Modal/ConnectModal.tsx
+++ b/packages/kit/src/components/Modal/ConnectModal.tsx
@@ -209,10 +209,14 @@ export const ConnectModal = (props: ConnectModalProps) => {
 
   const [activeWallet, setActiveWallet] = useState<IWallet | undefined>()
 
-  const handleSelectWallet = useCallback((wallet: IWallet) => {
+  const handleSelectWallet = useCallback(async (wallet: IWallet) => {
     setActiveWallet(wallet);
     if (wallet.installed) {
-      select(wallet.name);
+      try {
+        await select(wallet.name);
+      } catch (err) {
+        console.warn(err)
+      }
     }
   }, [select]);
 

--- a/packages/kit/src/hooks/useWallet.ts
+++ b/packages/kit/src/hooks/useWallet.ts
@@ -24,7 +24,7 @@ export interface WalletContextState {
   connecting: boolean;
   connected: boolean;
   status: "disconnected" | "connected" | "connecting";
-  select: (walletName: string) => void;
+  select: (walletName: string) => Promise<void>;
   disconnect: () => Promise<void>;
   getAccounts: () => readonly WalletAccount[];
 
@@ -76,7 +76,7 @@ const DEFAULT_CONTEXT: WalletContextState = {
   wallet: undefined,
   address: undefined,
   supportedWallets: [],
-  select() {
+  async select() {
     throw new KitError(missProviderMessage("select"));
   },
   on() {


### PR DESCRIPTION
I employed suiet wallet kit in my nextjs project. However, in the development mode, any uncaught error, such as the cancel of the wallet select, will lead to a error prompt, which influences the development flow.

I noticed in `WalletProvider`, the `connect` method is async, and it calls async `adapter.connect`. So I think the `connect` from context should also be async. It is my opinion that in this way, the framework won't catch the uncaught promise rejection, just like my situation that nextjs regards the cancel of user as uncaught error.

<img width="1351" alt="image" src="https://user-images.githubusercontent.com/22234622/219015473-9521f82e-f262-4dd3-ae9e-fc2537cc2e74.png">
