### PR TITLE
feat: support a specific error code for user rejection during wallet connection

### DIFF
--- a/packages/kit/src/errors/index.ts
+++ b/packages/kit/src/errors/index.ts
@@ -1,9 +1,13 @@
 export enum ErrorCode {
+  // general errors
   UNKNOWN_ERROR = "UNKNOWN_ERROR",
   KIT__UNKNOWN_ERROR = "KIT.UNKNOWN_ERROR",
   WALLET__UNKNOWN_ERROR = "WALLET.UNKNOWN_ERROR",
+  // connection errors
   WALLET__CONNECT_ERROR = "WALLET.CONNECT_ERROR",
+  WALLET__CONNECT_ERROR__USER_REJECTED = "WALLET.CONNECT_ERROR.USER_REJECTED",
   WALLET__DISCONNECT_ERROR = "WALLET.DISCONNECT_ERROR",
+  // sign errors
   WALLET__SIGN_TX_ERROR = "WALLET.SIGN_TX_ERROR",
   WALLET__SIGN_MSG_ERROR = "WALLET.SIGN_MSG_ERROR",
   WALLET__LISTEN_TO_EVENT_ERROR = "WALLET.LISTEN_TO_EVENT_ERROR",
@@ -22,18 +26,25 @@ export class BaseError extends Error {
     super(message);
     this.details = details;
     this.code = code;
+    this.message = this.formatErrorStr(code, message, details);
+  }
+
+  formatErrorStr(code: string, message: string, details?: Record<string, any>) {
+    let str = `[${this.code}] ${message}`
+    if (details) str += ' | details: ' + JSON.stringify(details)
+    return str
   }
 }
 
 export class KitError extends BaseError {
   constructor(message = "kit unknown error", code = ErrorCode.KIT__UNKNOWN_ERROR, details?: Record<string, any>) {
-    super('[KitError] ' + message, code, details);
+    super(message, code, details);
   }
 }
 
 export class WalletError extends BaseError {
   constructor(message = "wallet unknown error", code = ErrorCode.WALLET__UNKNOWN_ERROR, details?: Record<string, any>) {
-    super('[WalletError] ' + message, code, details);
+    super(message, code, details);
   }
 }
 

--- a/packages/kit/src/main.tsx
+++ b/packages/kit/src/main.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { WalletProvider, ConnectButton } from './components';
+import {ConnectButton, WalletProvider} from './components';
 import {useWallet} from "./hooks";
 import * as tweetnacl from 'tweetnacl';
+import {ErrorCode} from "./errors";
 
 function App() {
   const wallet = useWallet()
@@ -70,10 +71,16 @@ function App() {
       alignItems: 'center',
     }}>
       <ConnectButton
-        onConnectSuccess={(name) => {console.log('connect success!', name)}}
-        onConnectError={(err) => {console.warn('connect error!', err)}}
-        onDisconnectSuccess={(name) => {console.log('disconnect success!', name)}}
-        onDisconnectError={(err) => {console.log('disconnect error!', err)}}
+        onConnectSuccess={(name) => {console.log('connect success: ', name)}}
+        onConnectError={(err) => {
+          if (err.code === ErrorCode.WALLET__CONNECT_ERROR__USER_REJECTED) {
+            console.warn('user rejected the connection to ' + err.details?.wallet)
+          } else {
+            console.warn('unknown connect error: ', err)
+          }
+        }}
+        onDisconnectSuccess={(name) => {console.log('disconnect success: ', name)}}
+        onDisconnectError={(err) => {console.log('disconnect error: ', err)}}
       />
 
       {!wallet.connected ? (

--- a/packages/kit/src/wallet/wallet-adapter.ts
+++ b/packages/kit/src/wallet/wallet-adapter.ts
@@ -19,6 +19,7 @@ import {
   ExpSignMessageMethod,
   ExpSignMessageOutput
 } from "../wallet-standard/features/exp_sign-message";
+import {handleConnectionError} from "./wallet-error-handling";
 
 export enum FeatureName {
   STANDARD__CONNECT = "standard:connect",
@@ -70,7 +71,8 @@ export class WalletAdapter implements IWalletAdapter {
     try {
       return await feature.connect(input);
     } catch (e) {
-      throw new WalletError((e as any).message, ErrorCode.WALLET__CONNECT_ERROR)
+      const {code, message, details} = handleConnectionError(e as Error, this.name)
+      throw new WalletError(message, code, details)
     }
   }
 

--- a/packages/kit/src/wallet/wallet-error-handling.ts
+++ b/packages/kit/src/wallet/wallet-error-handling.ts
@@ -1,0 +1,44 @@
+import {ErrorCode} from "../errors";
+import {PresetWallet} from "./preset-wallets";
+
+export interface WalletErrorRes {
+  code: ErrorCode;
+  message: string;
+  details: Record<string, any>;
+}
+
+export function handleConnectionError(e: Error, wallet: string): WalletErrorRes {
+  let code = ErrorCode.WALLET__CONNECT_ERROR;  // default error
+  let message = e.message;
+  switch (wallet) {
+    case PresetWallet.SUI_WALLET:
+    case PresetWallet.ETHOS_WALLET:
+    case PresetWallet.GLASS_WALLET:
+    case PresetWallet.MORPHIS_WALLET:
+      if (message.includes('Permission rejected')) {
+        code = ErrorCode.WALLET__CONNECT_ERROR__USER_REJECTED
+      }
+      break;
+    case PresetWallet.SUIET_WALLET:
+      if (message.includes('User rejects approval')) {
+        code = ErrorCode.WALLET__CONNECT_ERROR__USER_REJECTED
+      }
+      break;
+    case PresetWallet.SPACECY_WALLET:
+      // NOTE: Spacecy wallet doesn't return any message
+      code = ErrorCode.WALLET__CONNECT_ERROR__USER_REJECTED
+      break;
+    case PresetWallet.SURF_WALLET:
+      if (message.includes('The user rejected the request')) {
+        code = ErrorCode.WALLET__CONNECT_ERROR__USER_REJECTED
+      }
+      break;
+  }
+  return {
+    code,
+    message,
+    details: {
+      wallet: wallet,
+    }
+  }
+}

--- a/website/docs/components/ConnectButton.md
+++ b/website/docs/components/ConnectButton.md
@@ -38,15 +38,20 @@ Sometimes you may want to hook in the connection events and do something with th
 >  If you are using hooks only, then simply wrap a try-catch block for the async  `select` method!
 
 ```jsx
-<ConnectButton 
-	
-/>
+import {WalletProvider, ConnectButton, ErrorCode, BaseError} from "@suiet/wallet-kit";
+
 function App() {
   return (
     <WalletProvider>
       <ConnectButton
-        onConnectError={(error) => {
-          console.log("Opps, something went wrong for the connection.", error);
+        // The BaseError instance has properties like {code, message, details}
+        // for developers to further customize their error handling.
+        onConnectError={(error: BaseError) => {
+           if (err.code === ErrorCode.WALLET__CONNECT_ERROR__USER_REJECTED) {
+             console.warn('user rejected the connection to ' + err.details?.wallet);
+           } else {
+             console.warn('unknown connect error: ', err);
+           }
         }}
       >Connect Wallet</ConnectButton>
     </WalletProvider>


### PR DESCRIPTION
As we enhanced our error handling for wallet connection, we can now detect precisely for the error reason during wallet connection.
Now developers can easily process thier custom logic when user rejects the connection request as follows:

```jsx
import {ConnectButton, ErrorCode, BaseError} from "@suiet/wallet-kit";

<ConnectButton
    onConnectError={(err: BaseError) => {
      if (err.code === ErrorCode.WALLET__CONNECT_ERROR__USER_REJECTED) {
        console.warn('user rejected the connection to ' + err.details?.wallet)
      } else {
        console.warn('unknown connect error: ', err)
      }
    }}
 />
```

The BaseError instance has properties like `code`, `message` and `details` for developers to further customize their error handling.
