### PR TITLE
Add exports field for sdk package

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,9 +13,17 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "dist/index.d.ts",
+      "import": "dist/index.js",
+      "require": "dist/index.js"
+    }
+  },
   "dependencies": {
     "@mysten/sui.js": "0.34.0",
     "@mysten/wallet-standard": "0.5.6",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,9 +19,8 @@
   ],
   "exports": {
     ".": {
-      "types": "dist/index.d.ts",
-      "import": "dist/index.js",
-      "require": "dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
add exports field such that the sdk package can be compatitble with most of the bundling tools