### PR TITLE
fix: disconnect issue

### DIFF
--- a/packages/sdk/src/utils/format/addressEllipsis.ts
+++ b/packages/sdk/src/utils/format/addressEllipsis.ts
@@ -1,6 +1,6 @@
 export default function addressEllipsis(address: string) {
   if (typeof address !== 'string') {
-    throw new Error('address is not a string');
+    return ''
   }
 
   // 0x0000000000000000000000000000000000000000 40bits / 42 length


### PR DESCRIPTION
change addressEllipsis function to return empty str instead of throwing an error when the input is not a string