### PR TITLE
Add `switchAccount` Method to Wallet Kit

### DIFF
--- a/packages/kit/src/hooks/useWallet.ts
+++ b/packages/kit/src/hooks/useWallet.ts
@@ -45,7 +45,20 @@ export interface WalletContextState {
   select: (walletName: string) => Promise<void>;
   disconnect: () => Promise<void>;
   getAccounts: () => readonly WalletAccount[];
-
+  /**
+   * Switch current account with the account that has the given address
+   * @param address - The address of the account to switch to
+   * @param opts - Optional options
+   * @param opts.onSuccess - Callback function to be called if the account is switched successfully
+   * @param opts.onError - Callback function to be called if the account is not switched successfully
+   */
+  switchAccount: (
+    address: WalletAccount["address"],
+    opts?: {
+      onSuccess?: () => void;
+      onError?: (error: Error) => void;
+    }
+  ) => void;
   signAndExecuteTransaction<Output extends SuiSignAndExecuteTransactionOutput>(
     input: Omit<SuiSignAndExecuteTransactionInput, "account" | "chain">,
     options?: ExecuteTransactionOptions
@@ -122,6 +135,9 @@ const DEFAULT_CONTEXT: WalletContextState = {
   },
   getAccounts() {
     throw new KitError(missProviderMessage("getAccounts"));
+  },
+  switchAccount() {
+    throw new KitError(missProviderMessage("switchAccount"));
   },
   async signTransaction() {
     throw new KitError(missProviderMessage("signTransaction"));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
       eslint-plugin-jest:
         specifier: ^27.2.2
-        version: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3)(typescript@5.6.3)
+        version: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)))(typescript@5.6.3)
       eslint-plugin-n:
         specifier: ^15.7.0
         version: 15.7.0(eslint@8.57.1)
@@ -254,8 +254,8 @@ importers:
         specifier: ^1.6.22
         version: 1.6.22(react@18.3.1)
       '@suiet/wallet-kit':
-        specifier: 0.3.5
-        version: 0.3.5(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        specifier: 0.3.7
+        version: 0.3.7(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2100,15 +2100,15 @@ packages:
   '@suchipi/femver@1.0.0':
     resolution: {integrity: sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==}
 
-  '@suiet/wallet-kit@0.3.5':
-    resolution: {integrity: sha512-Z+XZyHR92UCtRMywo2JwNyn2pOTMUPg5pIsmnRImXLk5g9rB4fmNPrQGnzYL/jcvD20pfHeSBwYC9NkCJYZ3WQ==}
+  '@suiet/wallet-kit@0.3.7':
+    resolution: {integrity: sha512-+WNZ1V5IfEcU5PCnaDxFgVA+8KierrrpkEJYdM36vNVALlURS7nWVf8mGWR8VhpQE2T5qoDAenTGt6e2Uktxaw==}
     peerDependencies:
       '@mysten/sui': 1.28.2
       react: '*'
       react-dom: '*'
 
-  '@suiet/wallet-sdk@0.3.4':
-    resolution: {integrity: sha512-3A8xYYQ2si7eIy/4VzesnCLJnZlWK42f/Yxse82I8dXX9ecCrlyotWuLuixThbzp3QNnKH5AFz6YytxVnycfCA==}
+  '@suiet/wallet-sdk@0.3.6':
+    resolution: {integrity: sha512-c6Cx5xtTPqLweCsxIr6BvB3PBn85InaHD8l+JODUip6L9OF8y7K20WeGXk0cFWWg1pCtm87f5rQIDsSVFzoBFw==}
     peerDependencies:
       '@mysten/sui': 1.28.2
 
@@ -9996,42 +9996,6 @@ snapshots:
       jest-util: 28.1.3
       slash: 3.0.0
 
-  '@jest/core@28.1.3':
-    dependencies:
-      '@jest/console': 28.1.3
-      '@jest/reporters': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/transform': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 20.4.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 28.1.3
-      jest-config: 28.1.3(@types/node@20.4.2)
-      jest-haste-map: 28.1.3
-      jest-message-util: 28.1.3
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-resolve-dependencies: 28.1.3
-      jest-runner: 28.1.3
-      jest-runtime: 28.1.3
-      jest-snapshot: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      jest-watcher: 28.1.3
-      micromatch: 4.0.8
-      pretty-format: 28.1.3
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    optional: true
-
   '@jest/core@28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))':
     dependencies:
       '@jest/console': 28.1.3
@@ -10101,6 +10065,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+
+  '@jest/core@28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))':
+    dependencies:
+      '@jest/console': 28.1.3
+      '@jest/reporters': 28.1.3
+      '@jest/test-result': 28.1.3
+      '@jest/transform': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/node': 20.4.2
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 28.1.3
+      jest-config: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+      jest-haste-map: 28.1.3
+      jest-message-util: 28.1.3
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-resolve-dependencies: 28.1.3
+      jest-runner: 28.1.3
+      jest-runtime: 28.1.3
+      jest-snapshot: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      jest-watcher: 28.1.3
+      micromatch: 4.0.8
+      pretty-format: 28.1.3
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    optional: true
 
   '@jest/environment@28.1.3':
     dependencies:
@@ -11221,14 +11221,14 @@ snapshots:
 
   '@suchipi/femver@1.0.0': {}
 
-  '@suiet/wallet-kit@0.3.5(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@suiet/wallet-kit@0.3.7(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
       '@mysten/slush-wallet': 0.1.0(typescript@5.6.3)
       '@mysten/sui': 1.28.2(typescript@5.6.3)
       '@mysten/wallet-standard': 0.14.7(typescript@5.6.3)
       '@mysten/zksend': 0.11.0(typescript@5.6.3)
       '@radix-ui/react-dialog': 1.0.2(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@suiet/wallet-sdk': 0.3.4(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)
+      '@suiet/wallet-sdk': 0.3.6(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)
       '@svgr/rollup': 6.5.1
       '@wallet-standard/core': 1.0.3
       buffer: 6.0.3
@@ -11246,7 +11246,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@suiet/wallet-sdk@0.3.4(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)':
+  '@suiet/wallet-sdk@0.3.6(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)':
     dependencies:
       '@mysten/slush-wallet': 0.1.0(typescript@5.6.3)
       '@mysten/sui': 1.28.2(typescript@5.6.3)
@@ -13445,13 +13445,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3)(typescript@5.6.3):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
-      jest: 28.1.3
+      jest: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -14711,26 +14711,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-cli@28.1.3:
-    dependencies:
-      '@jest/core': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/types': 28.1.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      import-local: 3.2.0
-      jest-config: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      prompts: 2.4.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    optional: true
-
   jest-cli@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
     dependencies:
       '@jest/core': 28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))
@@ -14769,62 +14749,24 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@28.1.3:
+  jest-cli@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
     dependencies:
-      '@babel/core': 7.25.8
-      '@jest/test-sequencer': 28.1.3
+      '@jest/core': 28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+      '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      babel-jest: 28.1.3(@babel/core@7.25.8)
       chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
+      exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
+      import-local: 3.2.0
+      jest-config: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
       jest-util: 28.1.3
       jest-validate: 28.1.3
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
+      prompts: 2.4.2
+      yargs: 17.7.2
     transitivePeerDependencies:
+      - '@types/node'
       - supports-color
-    optional: true
-
-  jest-config@28.1.3(@types/node@20.4.2):
-    dependencies:
-      '@babel/core': 7.25.8
-      '@jest/test-sequencer': 28.1.3
-      '@jest/types': 28.1.3
-      babel-jest: 28.1.3(@babel/core@7.25.8)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.4.2
-    transitivePeerDependencies:
-      - supports-color
+      - ts-node
     optional: true
 
   jest-config@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
@@ -14886,6 +14828,37 @@ snapshots:
       ts-node: 10.9.2(@types/node@20.4.2)(typescript@5.1.6)
     transitivePeerDependencies:
       - supports-color
+
+  jest-config@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
+    dependencies:
+      '@babel/core': 7.25.8
+      '@jest/test-sequencer': 28.1.3
+      '@jest/types': 28.1.3
+      babel-jest: 28.1.3(@babel/core@7.25.8)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 28.1.3
+      jest-environment-node: 28.1.3
+      jest-get-type: 28.0.2
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-runner: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.4.2
+      ts-node: 10.9.2(@types/node@20.4.2)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   jest-diff@28.1.3:
     dependencies:
@@ -15143,18 +15116,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@28.1.3:
-    dependencies:
-      '@jest/core': 28.1.3
-      '@jest/types': 28.1.3
-      import-local: 3.2.0
-      jest-cli: 28.1.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    optional: true
-
   jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
     dependencies:
       '@jest/core': 28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))
@@ -15176,6 +15137,18 @@ snapshots:
       - '@types/node'
       - supports-color
       - ts-node
+
+  jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
+    dependencies:
+      '@jest/core': 28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+      '@jest/types': 28.1.3
+      import-local: 3.2.0
+      jest-cli: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    optional: true
 
   jiti@1.21.6: {}
 
@@ -17620,6 +17593,25 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.1.6
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.4.2
+      acorn: 8.13.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true

--- a/website/docs/Hooks/useWallet.md
+++ b/website/docs/Hooks/useWallet.md
@@ -25,13 +25,13 @@ Make sure it runs in a React component under `WalletProvider`
 We start with a simple senario like getting information from the connected wallet .
 
 ```jsx
-import {useWallet} from '@suiet/wallet-kit'
+import { useWallet } from "@suiet/wallet-kit";
 
 function App() {
   const wallet = useWallet();
-  console.log('wallet status', wallet.status)
-  console.log('connected wallet name', wallet.name)
-  console.log('connected account info', wallet.account)
+  console.log("wallet status", wallet.status);
+  console.log("connected wallet name", wallet.name);
+  console.log("connected account info", wallet.account);
 }
 ```
 
@@ -47,13 +47,13 @@ batch transactions in one call.
 Here we define a `moveCall` transaction to implement a simple nft minting example.
 
 ```jsx
-import {useWallet} from '@suiet/wallet-kit'
+import { useWallet } from "@suiet/wallet-kit";
 
 function App() {
   const wallet = useWallet();
 
   async function handleSignAndExecuteTxBlock() {
-    if (!wallet.connected) return
+    if (!wallet.connected) return;
 
     // define a programmable transaction
     const tx = new TransactionBlock();
@@ -66,18 +66,16 @@ function App() {
     try {
       // execute the programmable transaction
       const resData = await wallet.signAndExecuteTransactionBlock({
-        transactionBlock: tx
+        transactionBlock: tx,
       });
-      console.log('nft minted successfully!', resData);
-      alert('Congrats! your nft is minted!')
+      console.log("nft minted successfully!", resData);
+      alert("Congrats! your nft is minted!");
     } catch (e) {
-      console.error('nft mint failed', e);
+      console.error("nft mint failed", e);
     }
   }
 
-  return (
-    <button onClick={handleSignAndExecuteTx}> Mint Your NFT !</button>
-  )
+  return <button onClick={handleSignAndExecuteTx}> Mint Your NFT !</button>;
 }
 ```
 
@@ -98,38 +96,42 @@ Here is an example for signing a simple message "Hello World".
 
 > Update: we prefer `signPersonalMessage` over `signMessage` according to the latest wallet standard.
 
-
 ```tsx
-import {useWallet} from '@suiet/wallet-kit'
-import * as tweetnacl from 'tweetnacl'
+import { useWallet } from "@suiet/wallet-kit";
+import * as tweetnacl from "tweetnacl";
 
 function App() {
   const wallet = useWallet();
 
   async function handleSignMsg() {
     try {
-      const msg = 'Hello world!'
-      // convert string to Uint8Array 
-      const msgBytes = new TextEncoder().encode(msg)
-      
+      const msg = "Hello world!";
+      // convert string to Uint8Array
+      const msgBytes = new TextEncoder().encode(msg);
+
       const result = await wallet.signPersonalMessage({
-        message: msgBytes
-      })
-			// verify signature with publicKey and SignedMessage (params are all included in result)
-      const verifyResult = await wallet.verifySignedMessage(result, wallet.account.publicKey)
+        message: msgBytes,
+      });
+      // verify signature with publicKey and SignedMessage (params are all included in result)
+      const verifyResult = await wallet.verifySignedMessage(
+        result,
+        wallet.account.publicKey
+      );
       if (!verifyResult) {
-        console.log('signPersonalMessage succeed, but verify signedMessage failed')
+        console.log(
+          "signPersonalMessage succeed, but verify signedMessage failed"
+        );
       } else {
-        console.log('signPersonalMessage succeed, and verify signedMessage succeed!')
+        console.log(
+          "signPersonalMessage succeed, and verify signedMessage succeed!"
+        );
       }
     } catch (e) {
-      console.error('signPersonalMessage failed', e)
+      console.error("signPersonalMessage failed", e);
     }
   }
 
-  return (
-    <button onClick={handleSignMsg}> Sign Message </button>
-  )
+  return <button onClick={handleSignMsg}> Sign Message </button>;
 }
 ```
 
@@ -142,28 +144,28 @@ information.
 
 :::
 
-Your dapp can get the current connected chain of wallet. 
+Your dapp can get the current connected chain of wallet.
 
 :::info
 For most wallets, if **user switches network inside the wallet**, the value **WOULD NOT** get updated. (Except for Suiet Wallet, we implemented this network change notification for a better development experience)
 
-This is because Sui team suggests each dapp should separate the environments for each chain (sui:devnet, sui:testnet, sui:mainnet). 
+This is because Sui team suggests each dapp should separate the environments for each chain (sui:devnet, sui:testnet, sui:mainnet).
 And the active chain returned by the connected wallet could be used to match the dapp's environment.
 
 In a nutshell, eliminating the need to switch network for dapp is a better user experience for a long term.
 :::
 
 ```tsx
-import {useWallet} from '@suiet/wallet-kit'
-import * as tweetnacl from 'tweetnacl'
+import { useWallet } from "@suiet/wallet-kit";
+import * as tweetnacl from "tweetnacl";
 
 function App() {
   const wallet = useWallet();
 
   useEffect(() => {
     if (!wallet.connected) return;
-    console.log('current connected chain (network)', wallet.chain?.name)  // example output: "sui:devnet", "sui:testnet" or "sui:mainnet"
-  }, [wallet.connected])
+    console.log("current connected chain (network)", wallet.chain?.name); // example output: "sui:devnet", "sui:testnet" or "sui:mainnet"
+  }, [wallet.connected]);
 }
 ```
 
@@ -181,19 +183,19 @@ The name of connected wallet.
 
 The connection status of wallet.
 
-| Properties | Type                                             | Default        |
-| ---------- | ------------------------------------------------ | -------------- |
-| connecting | boolean                                          | false          |
-| connected  | boolean                                          | false          |
+| Properties | Type                                          | Default        |
+| ---------- | --------------------------------------------- | -------------- |
+| connecting | boolean                                       | false          |
+| connected  | boolean                                       | false          |
 | status     | 'disconnected' \| 'connecting' \| 'connected' | 'disconnected' |
 
 ```ts
-const {status, connected, connecting} = useWallet();
+const { status, connected, connecting } = useWallet();
 
 // the assert expressions are equally the same
-assert(status === 'disconnected', !connecting && !connected); // not connect to wallet
-assert(status === 'connecting', connecting); // now connecting to the wallet
-assert(status === 'connected', connected); // connected to the wallet
+assert(status === "disconnected", !connecting && !connected); // not connect to wallet
+assert(status === "connecting", connecting); // now connecting to the wallet
+assert(status === "connected", connected); // connected to the wallet
 ```
 
 ### account
@@ -205,12 +207,12 @@ The account info in the connected wallet, including address, publicKey etc.
 | [WalletAccount](/docs/Types#WalletAccount) | undefined |
 
 ```ts
-const {connected, account} = useWallet();
+const { connected, account } = useWallet();
 
 function printAccountInfo() {
-  if (!connected) return
-  console.log(account?.address)
-  console.log(account?.publicKey)
+  if (!connected) return;
+  console.log(account?.address);
+  console.log(account?.publicKey);
 }
 ```
 
@@ -235,19 +237,67 @@ Get all the accessible accounts returned by wallet.
 The getAccounts will get the current wallet's account address. Now one wallet only have one account.
 
 ```jsx
-import {useWallet} from '@suiet/wallet-kit';
+import { useWallet } from "@suiet/wallet-kit";
 
 function YourComponent() {
   const wallet = useWallet();
 
   function handleGetAccounts() {
-    if (!wallet.connected) return
+    if (!wallet.connected) return;
     getAccounts().then((accounts) => {
       console.log(accounts);
-    })
+    });
   }
 }
 ```
+
+### switchAccount
+
+Switches the current main `account` to the one with the given address. Accepts optional callbacks for success and error handling.
+
+| Type                                                                                                      | Default |
+| --------------------------------------------------------------------------------------------------------- | ------- |
+| `(address: string, opts?: { onSuccess?: () => void; onError?: (error: Error) => void }) => Promise<void>` |         |
+
+```tsx
+import { useWallet } from "@suiet/wallet-kit";
+
+function YourComponent() {
+  const wallet = useWallet();
+
+  async function handleSwitchAccount() {
+    if (!wallet.connected) return;
+
+    try {
+      const accounts = await wallet.getAccounts();
+      if (accounts.length > 1) {
+        await wallet.switchAccount(accounts[1], {
+          onSuccess: () => {
+            console.log("Successfully switched to account:", accounts[1]);
+            // Handle successful account switch, e.g., update UI
+          },
+          onError: (error) => {
+            console.error("Failed to switch account:", error);
+            // Handle error, e.g., show error message to user
+          },
+        });
+      }
+    } catch (e) {
+      console.error("Failed to switch account:", e);
+    }
+  }
+
+  return <button onClick={handleSwitchAccount}>Switch Account</button>;
+}
+```
+
+:::caution
+Make sure the address you're switching to is available in the wallet's accounts. You can use `getAccounts()` to get the list of available addresses first.
+:::
+
+:::tip
+The `opts` parameter is optional. You can provide either both callbacks, just one, or none at all depending on your needs.
+:::
 
 ### chains
 
@@ -263,8 +313,8 @@ Current connected chain of wallet.
 
 Might not be synced with the wallet if the wallet doesn't support wallet-standard "change" event.
 
-| Type   | Default                                                      |
-| ------ | ------------------------------------------------------------ |
+| Type   | Default                                                                                 |
+| ------ | --------------------------------------------------------------------------------------- |
 | string | the first value of configured [chains](./#chains) or [UnknownChain](/docs/Types/#Chain) |
 
 ### adapter
@@ -273,8 +323,8 @@ The adapter normalized from the raw adapter of the connected wallet. You can cal
 it, which is followed
 the [@mysten/wallet-standard](https://github.com/MystenLabs/sui/tree/main/sdk/wallet-adapter/wallet-standard)
 
-| Type                             | Default   |
-|----------------------------------| --------- |
+| Type                                         | Default   |
+| -------------------------------------------- | --------- | --------- |
 | [IWalletAdapter](/docs/Types#IWalletAdapter) | undefined | undefined |
 
 ### signTransaction
@@ -282,9 +332,8 @@ the [@mysten/wallet-standard](https://github.com/MystenLabs/sui/tree/main/sdk/wa
 The function is for transaction signing.
 
 | Type                                                         | Default |
-|--------------------------------------------------------------| ------- |
+| ------------------------------------------------------------ | ------- |
 | `({transaction: Transaction}) => Promise<SignedTransaction>` |         |
-
 
 ### signAndExecuteTransaction
 
@@ -294,13 +343,13 @@ With this new feature, you can use the `signAndExecuteTransaction` method to sig
 
 This is an enhanced API of `signAndExecuteTransactionBlock` where the comparison between the two APIs are shown in the table.
 
-| API |     Execution     | FullNode for Execution |                   GraphQL API support                   | 
-|:-:|:-----------------:| :-: |:-------------------------------------------------------:|
-| signAndExecuteTransactionBlock |   on Wallet | Specified by Wallet |            Depend on wallet's implementation            |
-| signAndExecuteTransaction | on DApp | Specified by DApp |     Can be done by customizing the execute function     |           
+|              API               | Execution | FullNode for Execution |               GraphQL API support               |
+| :----------------------------: | :-------: | :--------------------: | :---------------------------------------------: |
+| signAndExecuteTransactionBlock | on Wallet |  Specified by Wallet   |        Depend on wallet's implementation        |
+|   signAndExecuteTransaction    |  on DApp  |   Specified by DApp    | Can be done by customizing the execute function |
 
 | Type                                                                                                                                                                                    | Default |
-|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `({transactionBlock: TransactionBlock, requestType?: ExecuteTransactionRequestType, options?: SuiTransactionBlockResponseOptions}) => Promise<SuiSignAndExecuteTransactionBlockOutput>` |         |
 
 ### signPersonalMessage
@@ -308,7 +357,7 @@ This is an enhanced API of `signAndExecuteTransactionBlock` where the comparison
 The function is for message signing.
 
 | Type                                                                            | Default |
-|---------------------------------------------------------------------------------| ------- |
+| ------------------------------------------------------------------------------- | ------- |
 | `(input: {message: Uint8Array}) => Promise<{signature: string; bytes: string}>` |         |
 
 ### verifySignedMessage
@@ -318,23 +367,23 @@ This function is for verifying the output of `signPersonalMessage` following the
 For details please check [here](https://github.com/suiet/wallet-kit/blob/main/packages/sdk/src/utils/verifySignedMessage.ts#L10)
 
 | Type                                                                     | Default |
-|--------------------------------------------------------------------------| ------- |
+| ------------------------------------------------------------------------ | ------- |
 | `(input: {signature: string; messageBytes: string}) => Promise<boolean>` |         |
 
 ### on
 
 The function for wallet event listening. Returns the off function to remove listener.
 
-| Type                                                         | Default |
-| ------------------------------------------------------------ | ------- |
+| Type                                                                                    | Default |
+| --------------------------------------------------------------------------------------- | ------- |
 | `<E extends WalletEvent>(event: E, listener: WalletEventListeners[E], ) => () => void;` |         |
 
 All the wallet events:
 
-| Event         | Listener                                                     | Description                                               |
-| ------------- | ------------------------------------------------------------ | --------------------------------------------------------- |
-| accountChange | `(params: { account: WalletAccount; }) => void;`             | Emit when wallet app changes its account                  |
-| featureChange | `(params: { features: string[]; }) => void;`                 | Emit when wallet app changes its wallet-standard features |
+| Event         | Listener                                                                               | Description                                               |
+| ------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| accountChange | `(params: { account: WalletAccount; }) => void;`                                       | Emit when wallet app changes its account                  |
+| featureChange | `(params: { features: string[]; }) => void;`                                           | Emit when wallet app changes its wallet-standard features |
 | change        | `(params: { chain?: string, account?: WalletAccount; features?: string[]; }) => void;` | Raw change event defined by wallet-standard               |
 
 ## Deprecated API
@@ -346,7 +395,7 @@ Deprecated, use [signAndExecuteTransaction](#signandexecutetransaction) instead.
 The universal function to send and execute transactions via connected wallet.
 
 | Type                                                                                                                                                                               | Default |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `({transactionBlock: Transaction, requestType?: ExecuteTransactionRequestType, options?: SuiTransactionBlockResponseOptions}) => Promise<SuiSignAndExecuteTransactionBlockOutput>` |         |
 
 ### signTransactionBlock
@@ -355,8 +404,8 @@ Deprecated, use [signTransaction](#signtransaction) instead.
 
 The function is for transaction signing.
 
-| Type                                                              | Default |
-|-------------------------------------------------------------------| ------- |
+| Type                                                                          | Default |
+| ----------------------------------------------------------------------------- | ------- |
 | `({transactionBlock: Transaction}) => Promise<SuiSignTransactionBlockOutput>` |         |
 
 ### executeMoveCall and executeSerializedMoveCall
@@ -388,6 +437,5 @@ const wallet = useWallet();
 Deprecated, use [signPersonalMessage](#signpersonalmessage) instead.
 
 | Type                                                                                   | Default |
-|----------------------------------------------------------------------------------------| ------- |
+| -------------------------------------------------------------------------------------- | ------- |
 | `(input: {message: Uint8Array}) => Promise<{signature: string; messageBytes: string}>` |         |
-


### PR DESCRIPTION
## Overview
This PR introduces a new `switchAccount` method to the Wallet Kit, allowing dApps to programmatically switch between different accounts within the connected wallet. This feature enhances the user experience by providing more flexibility in account management directly from dApps.

## Features
- New `switchAccount` method in `useWallet` hook
- Support for success and error callbacks
- TypeScript type definitions
- Full documentation with examples

## API
```typescript
type SwitchAccountOptions = {
  onSuccess?: () => void;
  onError?: (error: Error) => void;
};

switchAccount(address: string, opts?: SwitchAccountOptions): Promise<void>;
```

### Parameters
- `address`: The target account address to switch to
- `opts`: Optional callbacks for success and error handling
  - `onSuccess`: Called when the account switch is successful
  - `onError`: Called when the account switch fails

## Usage Example
```typescript
import { useWallet } from "@suiet/wallet-kit";

function YourComponent() {
  const wallet = useWallet();

  async function handleSwitchAccount() {
    if (!wallet.connected) return;
    
    try {
      const accounts = await wallet.getAccounts();
      if (accounts.length > 1) {
        await wallet.switchAccount(accounts[1], {
          onSuccess: () => {
            console.log('Successfully switched to account:', accounts[1]);
          },
          onError: (error) => {
            console.error('Failed to switch account:', error);
          }
        });
      }
    } catch (e) {
      console.error('Failed to switch account:', e);
    }
  }
}
```

## Documentation
- Added comprehensive documentation in the `useWallet.md` file
- Included usage examples and best practices
- Added TypeScript type definitions
- Documented error handling patterns

## Breaking Changes
None. This is a new feature that doesn't affect existing functionality.

## Dependencies
No new dependencies were added.

## Notes
- The method requires a connected wallet
- The target address must be available in the wallet's accounts
- Callbacks are optional

## Related Issues
https://github.com/suiet/wallet-kit/issues/309