### PR TITLE
Feat/adding switch account

### DIFF
--- a/packages/kit/src/components/WalletProvider.tsx
+++ b/packages/kit/src/components/WalletProvider.tsx
@@ -96,10 +96,10 @@ export const WalletProvider = (props: WalletProviderProps) => {
     return walletAdapter && status === ConnectionStatus.CONNECTED;
   };
 
-  const [account, setAccount] = useState<WalletAccount | undefined>(() => {
+  const account = useMemo<WalletAccount | undefined>(() => {
     if (!isCallable(walletAdapter, status)) return;
     return (walletAdapter as IWalletAdapter).accounts[0]; // use first account by default
-  });
+  }, [walletAdapter, status]);
 
   const ensureCallable = (
     walletAdapter: IWalletAdapter | undefined,
@@ -255,31 +255,6 @@ export const WalletProvider = (props: WalletProviderProps) => {
     const [_wallet] = safelyGetWalletAndAccount();
     return _wallet.accounts;
   }, [safelyGetWalletAndAccount]);
-
-  const switchAccount = useCallback(
-    (
-      address: WalletAccount["address"],
-      opts: {
-        onSuccess?: () => void;
-        onError?: (error: Error) => void;
-      } = {}
-    ) => {
-      const [_wallet] = safelyGetWalletAndAccount();
-
-      const account = _wallet.accounts.find((item) => item.address === address);
-
-      if (!account) {
-        opts?.onError?.(new KitError("account not found, or not connected"));
-
-        return;
-      }
-
-      setAccount(account);
-
-      opts?.onSuccess?.();
-    },
-    [safelyGetWalletAndAccount]
-  );
 
   const signAndExecuteTransactionBlock = useCallback(
     async (
@@ -507,7 +482,6 @@ export const WalletProvider = (props: WalletProviderProps) => {
         disconnect,
         on,
         getAccounts,
-        switchAccount,
         account,
         signPersonalMessage,
         signTransaction,

--- a/packages/kit/src/components/WalletProvider.tsx
+++ b/packages/kit/src/components/WalletProvider.tsx
@@ -96,10 +96,10 @@ export const WalletProvider = (props: WalletProviderProps) => {
     return walletAdapter && status === ConnectionStatus.CONNECTED;
   };
 
-  const account = useMemo<WalletAccount | undefined>(() => {
+  const [account, setAccount] = useState<WalletAccount | undefined>(() => {
     if (!isCallable(walletAdapter, status)) return;
     return (walletAdapter as IWalletAdapter).accounts[0]; // use first account by default
-  }, [walletAdapter, status]);
+  });
 
   const ensureCallable = (
     walletAdapter: IWalletAdapter | undefined,
@@ -255,6 +255,31 @@ export const WalletProvider = (props: WalletProviderProps) => {
     const [_wallet] = safelyGetWalletAndAccount();
     return _wallet.accounts;
   }, [safelyGetWalletAndAccount]);
+
+  const switchAccount = useCallback(
+    (
+      address: WalletAccount["address"],
+      opts: {
+        onSuccess?: () => void;
+        onError?: (error: Error) => void;
+      } = {}
+    ) => {
+      const [_wallet] = safelyGetWalletAndAccount();
+
+      const account = _wallet.accounts.find((item) => item.address === address);
+
+      if (!account) {
+        opts?.onError?.(new KitError("account not found, or not connected"));
+
+        return;
+      }
+
+      setAccount(account);
+
+      opts?.onSuccess?.();
+    },
+    [safelyGetWalletAndAccount]
+  );
 
   const signAndExecuteTransactionBlock = useCallback(
     async (
@@ -482,6 +507,7 @@ export const WalletProvider = (props: WalletProviderProps) => {
         disconnect,
         on,
         getAccounts,
+        switchAccount,
         account,
         signPersonalMessage,
         signTransaction,

--- a/packages/kit/src/hooks/useWallet.ts
+++ b/packages/kit/src/hooks/useWallet.ts
@@ -45,20 +45,7 @@ export interface WalletContextState {
   select: (walletName: string) => Promise<void>;
   disconnect: () => Promise<void>;
   getAccounts: () => readonly WalletAccount[];
-  /**
-   * Switch current account with the account that has the given address
-   * @param address - The address of the account to switch to
-   * @param opts - Optional options
-   * @param opts.onSuccess - Callback function to be called if the account is switched successfully
-   * @param opts.onError - Callback function to be called if the account is not switched successfully
-   */
-  switchAccount: (
-    address: WalletAccount["address"],
-    opts?: {
-      onSuccess?: () => void;
-      onError?: (error: Error) => void;
-    }
-  ) => void;
+
   signAndExecuteTransaction<Output extends SuiSignAndExecuteTransactionOutput>(
     input: Omit<SuiSignAndExecuteTransactionInput, "account" | "chain">,
     options?: ExecuteTransactionOptions
@@ -146,9 +133,6 @@ const DEFAULT_CONTEXT: WalletContextState = {
   },
   getAccounts() {
     throw new KitError(missProviderMessage("getAccounts"));
-  },
-  switchAccount() {
-    throw new KitError(missProviderMessage("switchAccount"));
   },
   async signTransaction() {
     throw new KitError(missProviderMessage("signTransaction"));

--- a/packages/kit/src/hooks/useWallet.ts
+++ b/packages/kit/src/hooks/useWallet.ts
@@ -45,7 +45,7 @@ export interface WalletContextState {
   select: (walletName: string) => Promise<void>;
   disconnect: () => Promise<void>;
   getAccounts: () => readonly WalletAccount[];
-
+  switchAccount: (address: WalletAccount["address"]) => Promise<WalletAccount>;
   signAndExecuteTransaction<Output extends SuiSignAndExecuteTransactionOutput>(
     input: Omit<SuiSignAndExecuteTransactionInput, "account" | "chain">,
     options?: ExecuteTransactionOptions
@@ -133,6 +133,9 @@ const DEFAULT_CONTEXT: WalletContextState = {
   },
   getAccounts() {
     throw new KitError(missProviderMessage("getAccounts"));
+  },
+  switchAccount() {
+    throw new KitError(missProviderMessage("switchAccount"));
   },
   async signTransaction() {
     throw new KitError(missProviderMessage("signTransaction"));

--- a/packages/kit/src/hooks/useWallet.ts
+++ b/packages/kit/src/hooks/useWallet.ts
@@ -45,7 +45,20 @@ export interface WalletContextState {
   select: (walletName: string) => Promise<void>;
   disconnect: () => Promise<void>;
   getAccounts: () => readonly WalletAccount[];
-
+  /**
+   * Switch current account with the account that has the given address
+   * @param address - The address of the account to switch to
+   * @param opts - Optional options
+   * @param opts.onSuccess - Callback function to be called if the account is switched successfully
+   * @param opts.onError - Callback function to be called if the account is not switched successfully
+   */
+  switchAccount: (
+    address: WalletAccount["address"],
+    opts?: {
+      onSuccess?: () => void;
+      onError?: (error: Error) => void;
+    }
+  ) => void;
   signAndExecuteTransaction<Output extends SuiSignAndExecuteTransactionOutput>(
     input: Omit<SuiSignAndExecuteTransactionInput, "account" | "chain">,
     options?: ExecuteTransactionOptions
@@ -133,6 +146,9 @@ const DEFAULT_CONTEXT: WalletContextState = {
   },
   getAccounts() {
     throw new KitError(missProviderMessage("getAccounts"));
+  },
+  switchAccount() {
+    throw new KitError(missProviderMessage("switchAccount"));
   },
   async signTransaction() {
     throw new KitError(missProviderMessage("signTransaction"));

--- a/packages/kit/src/main.tsx
+++ b/packages/kit/src/main.tsx
@@ -215,6 +215,27 @@ function App() {
     console.log("Environment detection results:", envInfo);
   };
 
+
+  const handleSwitchAccount = (address: string) => {
+    wallet.switchAccount(address);
+    console.log("switch account to: ", address);
+  }
+
+  const renderWalletAccounts = () => {
+    const accounts = wallet.getAccounts();
+    if (!accounts?.length) return null;
+    return <ol>
+      {accounts.map((account) => {
+        return <li key={account.address} onClick={() => handleSwitchAccount(account.address)}
+          style={{ cursor: "pointer" }}
+        >
+          <p>address: {account.address}</p>
+          <p>publicKey: {account.publicKey ?? "not supported"}</p>
+        </li>
+      })}
+    </ol>;
+  }
+
   // @ts-ignore
   return (
     <div
@@ -276,6 +297,8 @@ function App() {
             </p>
             <p>account address: {wallet.account?.address}</p>
             <p>account publicKey: {getPublicKey() || "not supported"}</p>
+            <p>Available Accounts:</p>
+            {renderWalletAccounts()}
             <p>
               current chain: {wallet.chain?.name} (id: {wallet.chain?.id})
             </p>

--- a/packages/kit/src/main.tsx
+++ b/packages/kit/src/main.tsx
@@ -216,12 +216,13 @@ function App() {
   };
 
 
-  const handleSwitchAccount = (address: string) => {
-    wallet.switchAccount(address);
-    console.log("switch account to: ", address);
+  const handleSwitchAccount = async (address: string) => {
+    const newAccount = await wallet.switchAccount(address);
+    console.log("switch account to: ", newAccount);
   }
 
   const renderWalletAccounts = () => {
+    if (!wallet.connected) return null;
     const accounts = wallet.getAccounts();
     if (!accounts?.length) return null;
     return <ol>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: ^1.6.22
         version: 1.6.22(react@18.3.1)
       '@suiet/wallet-kit':
-        specifier: 0.3.5
-        version: 0.3.5(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        specifier: 0.3.7
+        version: 0.3.7(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2100,15 +2100,15 @@ packages:
   '@suchipi/femver@1.0.0':
     resolution: {integrity: sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==}
 
-  '@suiet/wallet-kit@0.3.5':
-    resolution: {integrity: sha512-Z+XZyHR92UCtRMywo2JwNyn2pOTMUPg5pIsmnRImXLk5g9rB4fmNPrQGnzYL/jcvD20pfHeSBwYC9NkCJYZ3WQ==}
+  '@suiet/wallet-kit@0.3.7':
+    resolution: {integrity: sha512-+WNZ1V5IfEcU5PCnaDxFgVA+8KierrrpkEJYdM36vNVALlURS7nWVf8mGWR8VhpQE2T5qoDAenTGt6e2Uktxaw==}
     peerDependencies:
       '@mysten/sui': 1.28.2
       react: '*'
       react-dom: '*'
 
-  '@suiet/wallet-sdk@0.3.4':
-    resolution: {integrity: sha512-3A8xYYQ2si7eIy/4VzesnCLJnZlWK42f/Yxse82I8dXX9ecCrlyotWuLuixThbzp3QNnKH5AFz6YytxVnycfCA==}
+  '@suiet/wallet-sdk@0.3.6':
+    resolution: {integrity: sha512-c6Cx5xtTPqLweCsxIr6BvB3PBn85InaHD8l+JODUip6L9OF8y7K20WeGXk0cFWWg1pCtm87f5rQIDsSVFzoBFw==}
     peerDependencies:
       '@mysten/sui': 1.28.2
 
@@ -10394,7 +10394,7 @@ snapshots:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       '@mysten/bcs': 1.1.0
       '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.8.0
       '@scure/bip32': 1.5.0
       '@scure/bip39': 1.4.0
       '@suchipi/femver': 1.0.0
@@ -10451,7 +10451,7 @@ snapshots:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       '@mysten/bcs': 1.0.4
       '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.8.0
       '@scure/bip32': 1.5.0
       '@scure/bip39': 1.4.0
       '@suchipi/femver': 1.0.0
@@ -10470,7 +10470,7 @@ snapshots:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       '@mysten/bcs': 1.0.4
       '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.8.0
       '@scure/bip32': 1.5.0
       '@scure/bip39': 1.4.0
       '@suchipi/femver': 1.0.0
@@ -11221,14 +11221,14 @@ snapshots:
 
   '@suchipi/femver@1.0.0': {}
 
-  '@suiet/wallet-kit@0.3.5(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@suiet/wallet-kit@0.3.7(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
       '@mysten/slush-wallet': 0.1.0(typescript@5.6.3)
       '@mysten/sui': 1.28.2(typescript@5.6.3)
       '@mysten/wallet-standard': 0.14.7(typescript@5.6.3)
       '@mysten/zksend': 0.11.0(typescript@5.6.3)
       '@radix-ui/react-dialog': 1.0.2(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@suiet/wallet-sdk': 0.3.4(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)
+      '@suiet/wallet-sdk': 0.3.6(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)
       '@svgr/rollup': 6.5.1
       '@wallet-standard/core': 1.0.3
       buffer: 6.0.3
@@ -11246,7 +11246,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@suiet/wallet-sdk@0.3.4(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)':
+  '@suiet/wallet-sdk@0.3.6(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)':
     dependencies:
       '@mysten/slush-wallet': 0.1.0(typescript@5.6.3)
       '@mysten/sui': 1.28.2(typescript@5.6.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
       eslint-plugin-jest:
         specifier: ^27.2.2
-        version: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3)(typescript@5.6.3)
+        version: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)))(typescript@5.6.3)
       eslint-plugin-n:
         specifier: ^15.7.0
         version: 15.7.0(eslint@8.57.1)
@@ -9996,42 +9996,6 @@ snapshots:
       jest-util: 28.1.3
       slash: 3.0.0
 
-  '@jest/core@28.1.3':
-    dependencies:
-      '@jest/console': 28.1.3
-      '@jest/reporters': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/transform': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 20.4.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 28.1.3
-      jest-config: 28.1.3(@types/node@20.4.2)
-      jest-haste-map: 28.1.3
-      jest-message-util: 28.1.3
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-resolve-dependencies: 28.1.3
-      jest-runner: 28.1.3
-      jest-runtime: 28.1.3
-      jest-snapshot: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      jest-watcher: 28.1.3
-      micromatch: 4.0.8
-      pretty-format: 28.1.3
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    optional: true
-
   '@jest/core@28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))':
     dependencies:
       '@jest/console': 28.1.3
@@ -10101,6 +10065,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+
+  '@jest/core@28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))':
+    dependencies:
+      '@jest/console': 28.1.3
+      '@jest/reporters': 28.1.3
+      '@jest/test-result': 28.1.3
+      '@jest/transform': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/node': 20.4.2
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 28.1.3
+      jest-config: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+      jest-haste-map: 28.1.3
+      jest-message-util: 28.1.3
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-resolve-dependencies: 28.1.3
+      jest-runner: 28.1.3
+      jest-runtime: 28.1.3
+      jest-snapshot: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      jest-watcher: 28.1.3
+      micromatch: 4.0.8
+      pretty-format: 28.1.3
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    optional: true
 
   '@jest/environment@28.1.3':
     dependencies:
@@ -13445,13 +13445,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3)(typescript@5.6.3):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
-      jest: 28.1.3
+      jest: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -14711,26 +14711,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-cli@28.1.3:
-    dependencies:
-      '@jest/core': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/types': 28.1.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      import-local: 3.2.0
-      jest-config: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      prompts: 2.4.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    optional: true
-
   jest-cli@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
     dependencies:
       '@jest/core': 28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))
@@ -14769,62 +14749,24 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@28.1.3:
+  jest-cli@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
     dependencies:
-      '@babel/core': 7.25.8
-      '@jest/test-sequencer': 28.1.3
+      '@jest/core': 28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+      '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      babel-jest: 28.1.3(@babel/core@7.25.8)
       chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
+      exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
+      import-local: 3.2.0
+      jest-config: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
       jest-util: 28.1.3
       jest-validate: 28.1.3
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
+      prompts: 2.4.2
+      yargs: 17.7.2
     transitivePeerDependencies:
+      - '@types/node'
       - supports-color
-    optional: true
-
-  jest-config@28.1.3(@types/node@20.4.2):
-    dependencies:
-      '@babel/core': 7.25.8
-      '@jest/test-sequencer': 28.1.3
-      '@jest/types': 28.1.3
-      babel-jest: 28.1.3(@babel/core@7.25.8)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.4.2
-    transitivePeerDependencies:
-      - supports-color
+      - ts-node
     optional: true
 
   jest-config@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
@@ -14886,6 +14828,37 @@ snapshots:
       ts-node: 10.9.2(@types/node@20.4.2)(typescript@5.1.6)
     transitivePeerDependencies:
       - supports-color
+
+  jest-config@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
+    dependencies:
+      '@babel/core': 7.25.8
+      '@jest/test-sequencer': 28.1.3
+      '@jest/types': 28.1.3
+      babel-jest: 28.1.3(@babel/core@7.25.8)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 28.1.3
+      jest-environment-node: 28.1.3
+      jest-get-type: 28.0.2
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-runner: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.4.2
+      ts-node: 10.9.2(@types/node@20.4.2)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   jest-diff@28.1.3:
     dependencies:
@@ -15143,18 +15116,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@28.1.3:
-    dependencies:
-      '@jest/core': 28.1.3
-      '@jest/types': 28.1.3
-      import-local: 3.2.0
-      jest-cli: 28.1.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    optional: true
-
   jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
     dependencies:
       '@jest/core': 28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))
@@ -15176,6 +15137,18 @@ snapshots:
       - '@types/node'
       - supports-color
       - ts-node
+
+  jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
+    dependencies:
+      '@jest/core': 28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+      '@jest/types': 28.1.3
+      import-local: 3.2.0
+      jest-cli: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    optional: true
 
   jiti@1.21.6: {}
 
@@ -17620,6 +17593,25 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.1.6
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.4.2
+      acorn: 8.13.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
       eslint-plugin-jest:
         specifier: ^27.2.2
-        version: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3)(typescript@5.6.3)
       eslint-plugin-n:
         specifier: ^15.7.0
         version: 15.7.0(eslint@8.57.1)
@@ -254,8 +254,8 @@ importers:
         specifier: ^1.6.22
         version: 1.6.22(react@18.3.1)
       '@suiet/wallet-kit':
-        specifier: 0.3.7
-        version: 0.3.7(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        specifier: 0.3.5
+        version: 0.3.5(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2100,15 +2100,15 @@ packages:
   '@suchipi/femver@1.0.0':
     resolution: {integrity: sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==}
 
-  '@suiet/wallet-kit@0.3.7':
-    resolution: {integrity: sha512-+WNZ1V5IfEcU5PCnaDxFgVA+8KierrrpkEJYdM36vNVALlURS7nWVf8mGWR8VhpQE2T5qoDAenTGt6e2Uktxaw==}
+  '@suiet/wallet-kit@0.3.5':
+    resolution: {integrity: sha512-Z+XZyHR92UCtRMywo2JwNyn2pOTMUPg5pIsmnRImXLk5g9rB4fmNPrQGnzYL/jcvD20pfHeSBwYC9NkCJYZ3WQ==}
     peerDependencies:
       '@mysten/sui': 1.28.2
       react: '*'
       react-dom: '*'
 
-  '@suiet/wallet-sdk@0.3.6':
-    resolution: {integrity: sha512-c6Cx5xtTPqLweCsxIr6BvB3PBn85InaHD8l+JODUip6L9OF8y7K20WeGXk0cFWWg1pCtm87f5rQIDsSVFzoBFw==}
+  '@suiet/wallet-sdk@0.3.4':
+    resolution: {integrity: sha512-3A8xYYQ2si7eIy/4VzesnCLJnZlWK42f/Yxse82I8dXX9ecCrlyotWuLuixThbzp3QNnKH5AFz6YytxVnycfCA==}
     peerDependencies:
       '@mysten/sui': 1.28.2
 
@@ -9996,6 +9996,42 @@ snapshots:
       jest-util: 28.1.3
       slash: 3.0.0
 
+  '@jest/core@28.1.3':
+    dependencies:
+      '@jest/console': 28.1.3
+      '@jest/reporters': 28.1.3
+      '@jest/test-result': 28.1.3
+      '@jest/transform': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/node': 20.4.2
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 28.1.3
+      jest-config: 28.1.3(@types/node@20.4.2)
+      jest-haste-map: 28.1.3
+      jest-message-util: 28.1.3
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-resolve-dependencies: 28.1.3
+      jest-runner: 28.1.3
+      jest-runtime: 28.1.3
+      jest-snapshot: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      jest-watcher: 28.1.3
+      micromatch: 4.0.8
+      pretty-format: 28.1.3
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    optional: true
+
   '@jest/core@28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))':
     dependencies:
       '@jest/console': 28.1.3
@@ -10065,42 +10101,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - ts-node
-
-  '@jest/core@28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))':
-    dependencies:
-      '@jest/console': 28.1.3
-      '@jest/reporters': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/transform': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 20.4.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 28.1.3
-      jest-config: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
-      jest-haste-map: 28.1.3
-      jest-message-util: 28.1.3
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-resolve-dependencies: 28.1.3
-      jest-runner: 28.1.3
-      jest-runtime: 28.1.3
-      jest-snapshot: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      jest-watcher: 28.1.3
-      micromatch: 4.0.8
-      pretty-format: 28.1.3
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    optional: true
 
   '@jest/environment@28.1.3':
     dependencies:
@@ -11221,14 +11221,14 @@ snapshots:
 
   '@suchipi/femver@1.0.0': {}
 
-  '@suiet/wallet-kit@0.3.7(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@suiet/wallet-kit@0.3.5(@mysten/sui@1.28.2(typescript@5.6.3))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
       '@mysten/slush-wallet': 0.1.0(typescript@5.6.3)
       '@mysten/sui': 1.28.2(typescript@5.6.3)
       '@mysten/wallet-standard': 0.14.7(typescript@5.6.3)
       '@mysten/zksend': 0.11.0(typescript@5.6.3)
       '@radix-ui/react-dialog': 1.0.2(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@suiet/wallet-sdk': 0.3.6(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)
+      '@suiet/wallet-sdk': 0.3.4(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)
       '@svgr/rollup': 6.5.1
       '@wallet-standard/core': 1.0.3
       buffer: 6.0.3
@@ -11246,7 +11246,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@suiet/wallet-sdk@0.3.6(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)':
+  '@suiet/wallet-sdk@0.3.4(@mysten/sui@1.28.2(typescript@5.6.3))(typescript@5.6.3)':
     dependencies:
       '@mysten/slush-wallet': 0.1.0(typescript@5.6.3)
       '@mysten/sui': 1.28.2(typescript@5.6.3)
@@ -13445,13 +13445,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)))(typescript@5.6.3):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@28.1.3)(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
-      jest: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+      jest: 28.1.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -14711,6 +14711,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jest-cli@28.1.3:
+    dependencies:
+      '@jest/core': 28.1.3
+      '@jest/test-result': 28.1.3
+      '@jest/types': 28.1.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.2.0
+      jest-config: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      prompts: 2.4.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    optional: true
+
   jest-cli@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
     dependencies:
       '@jest/core': 28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))
@@ -14749,24 +14769,62 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
+  jest-config@28.1.3:
     dependencies:
-      '@jest/core': 28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
-      '@jest/test-result': 28.1.3
+      '@babel/core': 7.25.8
+      '@jest/test-sequencer': 28.1.3
       '@jest/types': 28.1.3
+      babel-jest: 28.1.3(@babel/core@7.25.8)
       chalk: 4.1.2
-      exit: 0.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
       graceful-fs: 4.2.11
-      import-local: 3.2.0
-      jest-config: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
+      jest-circus: 28.1.3
+      jest-environment-node: 28.1.3
+      jest-get-type: 28.0.2
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-runner: 28.1.3
       jest-util: 28.1.3
       jest-validate: 28.1.3
-      prompts: 2.4.2
-      yargs: 17.7.2
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
     transitivePeerDependencies:
-      - '@types/node'
       - supports-color
-      - ts-node
+    optional: true
+
+  jest-config@28.1.3(@types/node@20.4.2):
+    dependencies:
+      '@babel/core': 7.25.8
+      '@jest/test-sequencer': 28.1.3
+      '@jest/types': 28.1.3
+      babel-jest: 28.1.3(@babel/core@7.25.8)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 28.1.3
+      jest-environment-node: 28.1.3
+      jest-get-type: 28.0.2
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-runner: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.4.2
+    transitivePeerDependencies:
+      - supports-color
     optional: true
 
   jest-config@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
@@ -14828,37 +14886,6 @@ snapshots:
       ts-node: 10.9.2(@types/node@20.4.2)(typescript@5.1.6)
     transitivePeerDependencies:
       - supports-color
-
-  jest-config@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
-    dependencies:
-      '@babel/core': 7.25.8
-      '@jest/test-sequencer': 28.1.3
-      '@jest/types': 28.1.3
-      babel-jest: 28.1.3(@babel/core@7.25.8)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.4.2
-      ts-node: 10.9.2(@types/node@20.4.2)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   jest-diff@28.1.3:
     dependencies:
@@ -15116,6 +15143,18 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  jest@28.1.3:
+    dependencies:
+      '@jest/core': 28.1.3
+      '@jest/types': 28.1.3
+      import-local: 3.2.0
+      jest-cli: 28.1.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    optional: true
+
   jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6)):
     dependencies:
       '@jest/core': 28.1.3(ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6))
@@ -15137,18 +15176,6 @@ snapshots:
       - '@types/node'
       - supports-color
       - ts-node
-
-  jest@28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 28.1.3(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
-      '@jest/types': 28.1.3
-      import-local: 3.2.0
-      jest-cli: 28.1.3(@types/node@20.4.2)(ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    optional: true
 
   jiti@1.21.6: {}
 
@@ -17593,25 +17620,6 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.1.6
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@20.4.2)(typescript@5.6.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.4.2
-      acorn: 8.13.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true

--- a/website/docs/Hooks/useWallet.md
+++ b/website/docs/Hooks/useWallet.md
@@ -248,6 +248,48 @@ function YourComponent() {
 }
 ```
 
+### switchAccount
+
+Switches the current main `account` to the one with the given address. Accepts optional callbacks for success and error handling.
+
+| Type                                                                                                      | Default |
+| --------------------------------------------------------------------------------------------------------- | ------- |
+| `(address: string) => Promise<WalletAccount>` |         |
+
+```tsx
+import { useWallet } from "@suiet/wallet-kit";
+
+function YourComponent() {
+  const wallet = useWallet();
+
+  async function handleSwitchAccount() {
+    if (!wallet.connected) return;
+
+    const accounts = await wallet.getAccounts();
+    try {
+      if (accounts.length > 1) {
+        const newAccount = await wallet.switchAccount(accounts[1]);
+        console.log('Successfully switched to new account: ', newAccount)
+      } else {
+        console.log('Failed to switch account due to only one proposed account by wallet')
+      }
+    } catch (e) {
+      console.error("Failed to switch account:", e);
+    }
+  }
+
+  return <button onClick={handleSwitchAccount}>Switch Account</button>;
+}
+```
+
+:::caution
+Make sure the address you're switching to is available in the wallet's accounts. You can use `getAccounts()` to get the list of available addresses first.
+:::
+
+:::tip
+The `opts` parameter is optional. You can provide either both callbacks, just one, or none at all depending on your needs.
+:::
+
 ### chains
 
 Configuration of supported chains from WalletProvider

--- a/website/docs/Hooks/useWallet.md
+++ b/website/docs/Hooks/useWallet.md
@@ -25,13 +25,13 @@ Make sure it runs in a React component under `WalletProvider`
 We start with a simple senario like getting information from the connected wallet .
 
 ```jsx
-import {useWallet} from '@suiet/wallet-kit'
+import { useWallet } from "@suiet/wallet-kit";
 
 function App() {
   const wallet = useWallet();
-  console.log('wallet status', wallet.status)
-  console.log('connected wallet name', wallet.name)
-  console.log('connected account info', wallet.account)
+  console.log("wallet status", wallet.status);
+  console.log("connected wallet name", wallet.name);
+  console.log("connected account info", wallet.account);
 }
 ```
 
@@ -47,13 +47,13 @@ batch transactions in one call.
 Here we define a `moveCall` transaction to implement a simple nft minting example.
 
 ```jsx
-import {useWallet} from '@suiet/wallet-kit'
+import { useWallet } from "@suiet/wallet-kit";
 
 function App() {
   const wallet = useWallet();
 
   async function handleSignAndExecuteTxBlock() {
-    if (!wallet.connected) return
+    if (!wallet.connected) return;
 
     // define a programmable transaction
     const tx = new TransactionBlock();
@@ -66,18 +66,16 @@ function App() {
     try {
       // execute the programmable transaction
       const resData = await wallet.signAndExecuteTransactionBlock({
-        transactionBlock: tx
+        transactionBlock: tx,
       });
-      console.log('nft minted successfully!', resData);
-      alert('Congrats! your nft is minted!')
+      console.log("nft minted successfully!", resData);
+      alert("Congrats! your nft is minted!");
     } catch (e) {
-      console.error('nft mint failed', e);
+      console.error("nft mint failed", e);
     }
   }
 
-  return (
-    <button onClick={handleSignAndExecuteTx}> Mint Your NFT !</button>
-  )
+  return <button onClick={handleSignAndExecuteTx}> Mint Your NFT !</button>;
 }
 ```
 
@@ -98,36 +96,38 @@ Here is an example for signing a simple message "Hello World".
 
 
 ```tsx
-import {useWallet} from '@suiet/wallet-kit'
-import * as tweetnacl from 'tweetnacl'
+import { useWallet } from "@suiet/wallet-kit";
+import * as tweetnacl from "tweetnacl";
 
 function App() {
   const wallet = useWallet();
 
   async function handleSignMsg() {
     try {
-      const msg = 'Hello world!'
-      // convert string to Uint8Array 
-      const msgBytes = new TextEncoder().encode(msg)
-      
+      const msg = "Hello world!";
+      // convert string to Uint8Array
+      const msgBytes = new TextEncoder().encode(msg);
+
       const result = await wallet.signPersonalMessage({
         message: msgBytes
       })
       // directly input the signed result for verification
       const verifyResult = await wallet.verifySignedPersonalMessage(result)
       if (!verifyResult) {
-        console.log('signPersonalMessage succeed, but verify signedMessage failed')
+        console.log(
+          "signPersonalMessage succeed, but verify signedMessage failed"
+        );
       } else {
-        console.log('signPersonalMessage succeed, and verify signedMessage succeed!')
+        console.log(
+          "signPersonalMessage succeed, and verify signedMessage succeed!"
+        );
       }
     } catch (e) {
-      console.error('signPersonalMessage failed', e)
+      console.error("signPersonalMessage failed", e);
     }
   }
 
-  return (
-    <button onClick={handleSignMsg}> Sign Message </button>
-  )
+  return <button onClick={handleSignMsg}> Sign Message </button>;
 }
 ```
 
@@ -140,28 +140,28 @@ information.
 
 :::
 
-Your dapp can get the current connected chain of wallet. 
+Your dapp can get the current connected chain of wallet.
 
 :::info
 For most wallets, if **user switches network inside the wallet**, the value **WOULD NOT** get updated. (Except for Suiet Wallet, we implemented this network change notification for a better development experience)
 
-This is because Sui team suggests each dapp should separate the environments for each chain (sui:devnet, sui:testnet, sui:mainnet). 
+This is because Sui team suggests each dapp should separate the environments for each chain (sui:devnet, sui:testnet, sui:mainnet).
 And the active chain returned by the connected wallet could be used to match the dapp's environment.
 
 In a nutshell, eliminating the need to switch network for dapp is a better user experience for a long term.
 :::
 
 ```tsx
-import {useWallet} from '@suiet/wallet-kit'
-import * as tweetnacl from 'tweetnacl'
+import { useWallet } from "@suiet/wallet-kit";
+import * as tweetnacl from "tweetnacl";
 
 function App() {
   const wallet = useWallet();
 
   useEffect(() => {
     if (!wallet.connected) return;
-    console.log('current connected chain (network)', wallet.chain?.name)  // example output: "sui:devnet", "sui:testnet" or "sui:mainnet"
-  }, [wallet.connected])
+    console.log("current connected chain (network)", wallet.chain?.name); // example output: "sui:devnet", "sui:testnet" or "sui:mainnet"
+  }, [wallet.connected]);
 }
 ```
 
@@ -179,19 +179,19 @@ The name of connected wallet.
 
 The connection status of wallet.
 
-| Properties | Type                                             | Default        |
-| ---------- | ------------------------------------------------ | -------------- |
-| connecting | boolean                                          | false          |
-| connected  | boolean                                          | false          |
+| Properties | Type                                          | Default        |
+| ---------- | --------------------------------------------- | -------------- |
+| connecting | boolean                                       | false          |
+| connected  | boolean                                       | false          |
 | status     | 'disconnected' \| 'connecting' \| 'connected' | 'disconnected' |
 
 ```ts
-const {status, connected, connecting} = useWallet();
+const { status, connected, connecting } = useWallet();
 
 // the assert expressions are equally the same
-assert(status === 'disconnected', !connecting && !connected); // not connect to wallet
-assert(status === 'connecting', connecting); // now connecting to the wallet
-assert(status === 'connected', connected); // connected to the wallet
+assert(status === "disconnected", !connecting && !connected); // not connect to wallet
+assert(status === "connecting", connecting); // now connecting to the wallet
+assert(status === "connected", connected); // connected to the wallet
 ```
 
 ### account
@@ -203,12 +203,12 @@ The account info in the connected wallet, including address, publicKey etc.
 | [WalletAccount](/docs/Types#WalletAccount) | undefined |
 
 ```ts
-const {connected, account} = useWallet();
+const { connected, account } = useWallet();
 
 function printAccountInfo() {
-  if (!connected) return
-  console.log(account?.address)
-  console.log(account?.publicKey)
+  if (!connected) return;
+  console.log(account?.address);
+  console.log(account?.publicKey);
 }
 ```
 
@@ -233,19 +233,67 @@ Get all the accessible accounts returned by wallet.
 The getAccounts will get the current wallet's account address. Now one wallet only have one account.
 
 ```jsx
-import {useWallet} from '@suiet/wallet-kit';
+import { useWallet } from "@suiet/wallet-kit";
 
 function YourComponent() {
   const wallet = useWallet();
 
   function handleGetAccounts() {
-    if (!wallet.connected) return
+    if (!wallet.connected) return;
     getAccounts().then((accounts) => {
       console.log(accounts);
-    })
+    });
   }
 }
 ```
+
+### switchAccount
+
+Switches the current main `account` to the one with the given address. Accepts optional callbacks for success and error handling.
+
+| Type                                                                                                      | Default |
+| --------------------------------------------------------------------------------------------------------- | ------- |
+| `(address: string, opts?: { onSuccess?: () => void; onError?: (error: Error) => void }) => Promise<void>` |         |
+
+```tsx
+import { useWallet } from "@suiet/wallet-kit";
+
+function YourComponent() {
+  const wallet = useWallet();
+
+  async function handleSwitchAccount() {
+    if (!wallet.connected) return;
+
+    try {
+      const accounts = await wallet.getAccounts();
+      if (accounts.length > 1) {
+        await wallet.switchAccount(accounts[1], {
+          onSuccess: () => {
+            console.log("Successfully switched to account:", accounts[1]);
+            // Handle successful account switch, e.g., update UI
+          },
+          onError: (error) => {
+            console.error("Failed to switch account:", error);
+            // Handle error, e.g., show error message to user
+          },
+        });
+      }
+    } catch (e) {
+      console.error("Failed to switch account:", e);
+    }
+  }
+
+  return <button onClick={handleSwitchAccount}>Switch Account</button>;
+}
+```
+
+:::caution
+Make sure the address you're switching to is available in the wallet's accounts. You can use `getAccounts()` to get the list of available addresses first.
+:::
+
+:::tip
+The `opts` parameter is optional. You can provide either both callbacks, just one, or none at all depending on your needs.
+:::
 
 ### chains
 
@@ -261,8 +309,8 @@ Current connected chain of wallet.
 
 Might not be synced with the wallet if the wallet doesn't support wallet-standard "change" event.
 
-| Type   | Default                                                      |
-| ------ | ------------------------------------------------------------ |
+| Type   | Default                                                                                 |
+| ------ | --------------------------------------------------------------------------------------- |
 | string | the first value of configured [chains](./#chains) or [UnknownChain](/docs/Types/#Chain) |
 
 ### adapter
@@ -271,8 +319,8 @@ The adapter normalized from the raw adapter of the connected wallet. You can cal
 it, which is followed
 the [@mysten/wallet-standard](https://github.com/MystenLabs/sui/tree/main/sdk/wallet-adapter/wallet-standard)
 
-| Type                             | Default   |
-|----------------------------------| --------- |
+| Type                                         | Default   |
+| -------------------------------------------- | --------- | --------- |
 | [IWalletAdapter](/docs/Types#IWalletAdapter) | undefined | undefined |
 
 ### signTransaction
@@ -280,9 +328,8 @@ the [@mysten/wallet-standard](https://github.com/MystenLabs/sui/tree/main/sdk/wa
 The function is for transaction signing.
 
 | Type                                                         | Default |
-|--------------------------------------------------------------| ------- |
+| ------------------------------------------------------------ | ------- |
 | `({transaction: Transaction}) => Promise<SignedTransaction>` |         |
-
 
 ### signAndExecuteTransaction
 
@@ -292,13 +339,13 @@ With this new feature, you can use the `signAndExecuteTransaction` method to sig
 
 This is an enhanced API of `signAndExecuteTransactionBlock` where the comparison between the two APIs are shown in the table.
 
-| API |     Execution     | FullNode for Execution |                   GraphQL API support                   | 
-|:-:|:-----------------:| :-: |:-------------------------------------------------------:|
-| signAndExecuteTransactionBlock |   on Wallet | Specified by Wallet |            Depend on wallet's implementation            |
-| signAndExecuteTransaction | on DApp | Specified by DApp |     Can be done by customizing the execute function     |           
+|              API               | Execution | FullNode for Execution |               GraphQL API support               |
+| :----------------------------: | :-------: | :--------------------: | :---------------------------------------------: |
+| signAndExecuteTransactionBlock | on Wallet |  Specified by Wallet   |        Depend on wallet's implementation        |
+|   signAndExecuteTransaction    |  on DApp  |   Specified by DApp    | Can be done by customizing the execute function |
 
 | Type                                                                                                                                                                                    | Default |
-|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `({transactionBlock: TransactionBlock, requestType?: ExecuteTransactionRequestType, options?: SuiTransactionBlockResponseOptions}) => Promise<SuiSignAndExecuteTransactionBlockOutput>` |         |
 
 ### signPersonalMessage
@@ -306,7 +353,7 @@ This is an enhanced API of `signAndExecuteTransactionBlock` where the comparison
 The function is for personal message signing. The return strings are in base64 format.
 
 | Type                                                                            | Default |
-|---------------------------------------------------------------------------------| ------- |
+| ------------------------------------------------------------------------------- | ------- |
 | `(input: {message: Uint8Array}) => Promise<{signature: string; bytes: string}>` |         |
 
 ### verifySignedPersonalMessage
@@ -337,16 +384,16 @@ It supports signatures of multiple schemes, such as  ed25519, secp256k1, secp256
 
 The function for wallet event listening. Returns the off function to remove listener.
 
-| Type                                                         | Default |
-| ------------------------------------------------------------ | ------- |
+| Type                                                                                    | Default |
+| --------------------------------------------------------------------------------------- | ------- |
 | `<E extends WalletEvent>(event: E, listener: WalletEventListeners[E], ) => () => void;` |         |
 
 All the wallet events:
 
-| Event         | Listener                                                     | Description                                               |
-| ------------- | ------------------------------------------------------------ | --------------------------------------------------------- |
-| accountChange | `(params: { account: WalletAccount; }) => void;`             | Emit when wallet app changes its account                  |
-| featureChange | `(params: { features: string[]; }) => void;`                 | Emit when wallet app changes its wallet-standard features |
+| Event         | Listener                                                                               | Description                                               |
+| ------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| accountChange | `(params: { account: WalletAccount; }) => void;`                                       | Emit when wallet app changes its account                  |
+| featureChange | `(params: { features: string[]; }) => void;`                                           | Emit when wallet app changes its wallet-standard features |
 | change        | `(params: { chain?: string, account?: WalletAccount; features?: string[]; }) => void;` | Raw change event defined by wallet-standard               |
 
 ## Deprecated API
@@ -358,7 +405,7 @@ Deprecated, use [signAndExecuteTransaction](#signandexecutetransaction) instead.
 The universal function to send and execute transactions via connected wallet.
 
 | Type                                                                                                                                                                               | Default |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `({transactionBlock: Transaction, requestType?: ExecuteTransactionRequestType, options?: SuiTransactionBlockResponseOptions}) => Promise<SuiSignAndExecuteTransactionBlockOutput>` |         |
 
 ### signTransactionBlock
@@ -367,8 +414,8 @@ Deprecated, use [signTransaction](#signtransaction) instead.
 
 The function is for transaction signing.
 
-| Type                                                              | Default |
-|-------------------------------------------------------------------| ------- |
+| Type                                                                          | Default |
+| ----------------------------------------------------------------------------- | ------- |
 | `({transactionBlock: Transaction}) => Promise<SuiSignTransactionBlockOutput>` |         |
 
 ### executeMoveCall and executeSerializedMoveCall
@@ -400,7 +447,7 @@ const wallet = useWallet();
 Deprecated, use [signPersonalMessage](#signpersonalmessage) instead.
 
 | Type                                                                                   | Default |
-|----------------------------------------------------------------------------------------| ------- |
+| -------------------------------------------------------------------------------------- | ------- |
 | `(input: {message: Uint8Array}) => Promise<{signature: string; messageBytes: string}>` |         |
 
 

--- a/website/docs/Hooks/useWallet.md
+++ b/website/docs/Hooks/useWallet.md
@@ -229,9 +229,9 @@ Get all the accessible accounts returned by wallet.
 
 | Type                    | Default |
 | ----------------------- | ------- |
-| () => Promise<string[]> |         |
+| () => string[] |         |
 
-The getAccounts will get the current wallet's account address. Now one wallet only have one account.
+The getAccounts will return the permitted account list of the current wallet.
 
 ```jsx
 import {useWallet} from '@suiet/wallet-kit';
@@ -241,9 +241,7 @@ function YourComponent() {
 
   function handleGetAccounts() {
     if (!wallet.connected) return
-    getAccounts().then((accounts) => {
-      console.log(accounts);
-    })
+    const accounts = getAccounts()
   }
 }
 ```
@@ -265,7 +263,7 @@ function YourComponent() {
   async function handleSwitchAccount() {
     if (!wallet.connected) return;
 
-    const accounts = await wallet.getAccounts();
+    const accounts = wallet.getAccounts();
     try {
       if (accounts.length > 1) {
         const newAccount = await wallet.switchAccount(accounts[1]);

--- a/website/docs/Hooks/useWallet.md
+++ b/website/docs/Hooks/useWallet.md
@@ -25,13 +25,13 @@ Make sure it runs in a React component under `WalletProvider`
 We start with a simple senario like getting information from the connected wallet .
 
 ```jsx
-import { useWallet } from "@suiet/wallet-kit";
+import {useWallet} from '@suiet/wallet-kit'
 
 function App() {
   const wallet = useWallet();
-  console.log("wallet status", wallet.status);
-  console.log("connected wallet name", wallet.name);
-  console.log("connected account info", wallet.account);
+  console.log('wallet status', wallet.status)
+  console.log('connected wallet name', wallet.name)
+  console.log('connected account info', wallet.account)
 }
 ```
 
@@ -47,13 +47,13 @@ batch transactions in one call.
 Here we define a `moveCall` transaction to implement a simple nft minting example.
 
 ```jsx
-import { useWallet } from "@suiet/wallet-kit";
+import {useWallet} from '@suiet/wallet-kit'
 
 function App() {
   const wallet = useWallet();
 
   async function handleSignAndExecuteTxBlock() {
-    if (!wallet.connected) return;
+    if (!wallet.connected) return
 
     // define a programmable transaction
     const tx = new TransactionBlock();
@@ -66,16 +66,18 @@ function App() {
     try {
       // execute the programmable transaction
       const resData = await wallet.signAndExecuteTransactionBlock({
-        transactionBlock: tx,
+        transactionBlock: tx
       });
-      console.log("nft minted successfully!", resData);
-      alert("Congrats! your nft is minted!");
+      console.log('nft minted successfully!', resData);
+      alert('Congrats! your nft is minted!')
     } catch (e) {
-      console.error("nft mint failed", e);
+      console.error('nft mint failed', e);
     }
   }
 
-  return <button onClick={handleSignAndExecuteTx}> Mint Your NFT !</button>;
+  return (
+    <button onClick={handleSignAndExecuteTx}> Mint Your NFT !</button>
+  )
 }
 ```
 
@@ -95,39 +97,38 @@ Here is an example for signing a simple message "Hello World".
 > use [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) to encode and decode.
 
 
+
 ```tsx
-import { useWallet } from "@suiet/wallet-kit";
-import * as tweetnacl from "tweetnacl";
+import {useWallet} from '@suiet/wallet-kit'
+import * as tweetnacl from 'tweetnacl'
 
 function App() {
   const wallet = useWallet();
 
   async function handleSignMsg() {
     try {
-      const msg = "Hello world!";
-      // convert string to Uint8Array
-      const msgBytes = new TextEncoder().encode(msg);
-
+      const msg = 'Hello world!'
+      // convert string to Uint8Array 
+      const msgBytes = new TextEncoder().encode(msg)
+      
       const result = await wallet.signPersonalMessage({
         message: msgBytes
       })
       // directly input the signed result for verification
       const verifyResult = await wallet.verifySignedPersonalMessage(result)
       if (!verifyResult) {
-        console.log(
-          "signPersonalMessage succeed, but verify signedMessage failed"
-        );
+        console.log('signPersonalMessage succeed, but verify signedMessage failed')
       } else {
-        console.log(
-          "signPersonalMessage succeed, and verify signedMessage succeed!"
-        );
+        console.log('signPersonalMessage succeed, and verify signedMessage succeed!')
       }
     } catch (e) {
-      console.error("signPersonalMessage failed", e);
+      console.error('signPersonalMessage failed', e)
     }
   }
 
-  return <button onClick={handleSignMsg}> Sign Message </button>;
+  return (
+    <button onClick={handleSignMsg}> Sign Message </button>
+  )
 }
 ```
 
@@ -140,28 +141,28 @@ information.
 
 :::
 
-Your dapp can get the current connected chain of wallet.
+Your dapp can get the current connected chain of wallet. 
 
 :::info
 For most wallets, if **user switches network inside the wallet**, the value **WOULD NOT** get updated. (Except for Suiet Wallet, we implemented this network change notification for a better development experience)
 
-This is because Sui team suggests each dapp should separate the environments for each chain (sui:devnet, sui:testnet, sui:mainnet).
+This is because Sui team suggests each dapp should separate the environments for each chain (sui:devnet, sui:testnet, sui:mainnet). 
 And the active chain returned by the connected wallet could be used to match the dapp's environment.
 
 In a nutshell, eliminating the need to switch network for dapp is a better user experience for a long term.
 :::
 
 ```tsx
-import { useWallet } from "@suiet/wallet-kit";
-import * as tweetnacl from "tweetnacl";
+import {useWallet} from '@suiet/wallet-kit'
+import * as tweetnacl from 'tweetnacl'
 
 function App() {
   const wallet = useWallet();
 
   useEffect(() => {
     if (!wallet.connected) return;
-    console.log("current connected chain (network)", wallet.chain?.name); // example output: "sui:devnet", "sui:testnet" or "sui:mainnet"
-  }, [wallet.connected]);
+    console.log('current connected chain (network)', wallet.chain?.name)  // example output: "sui:devnet", "sui:testnet" or "sui:mainnet"
+  }, [wallet.connected])
 }
 ```
 
@@ -179,19 +180,19 @@ The name of connected wallet.
 
 The connection status of wallet.
 
-| Properties | Type                                          | Default        |
-| ---------- | --------------------------------------------- | -------------- |
-| connecting | boolean                                       | false          |
-| connected  | boolean                                       | false          |
+| Properties | Type                                             | Default        |
+| ---------- | ------------------------------------------------ | -------------- |
+| connecting | boolean                                          | false          |
+| connected  | boolean                                          | false          |
 | status     | 'disconnected' \| 'connecting' \| 'connected' | 'disconnected' |
 
 ```ts
-const { status, connected, connecting } = useWallet();
+const {status, connected, connecting} = useWallet();
 
 // the assert expressions are equally the same
-assert(status === "disconnected", !connecting && !connected); // not connect to wallet
-assert(status === "connecting", connecting); // now connecting to the wallet
-assert(status === "connected", connected); // connected to the wallet
+assert(status === 'disconnected', !connecting && !connected); // not connect to wallet
+assert(status === 'connecting', connecting); // now connecting to the wallet
+assert(status === 'connected', connected); // connected to the wallet
 ```
 
 ### account
@@ -203,12 +204,12 @@ The account info in the connected wallet, including address, publicKey etc.
 | [WalletAccount](/docs/Types#WalletAccount) | undefined |
 
 ```ts
-const { connected, account } = useWallet();
+const {connected, account} = useWallet();
 
 function printAccountInfo() {
-  if (!connected) return;
-  console.log(account?.address);
-  console.log(account?.publicKey);
+  if (!connected) return
+  console.log(account?.address)
+  console.log(account?.publicKey)
 }
 ```
 
@@ -233,67 +234,19 @@ Get all the accessible accounts returned by wallet.
 The getAccounts will get the current wallet's account address. Now one wallet only have one account.
 
 ```jsx
-import { useWallet } from "@suiet/wallet-kit";
+import {useWallet} from '@suiet/wallet-kit';
 
 function YourComponent() {
   const wallet = useWallet();
 
   function handleGetAccounts() {
-    if (!wallet.connected) return;
+    if (!wallet.connected) return
     getAccounts().then((accounts) => {
       console.log(accounts);
-    });
+    })
   }
 }
 ```
-
-### switchAccount
-
-Switches the current main `account` to the one with the given address. Accepts optional callbacks for success and error handling.
-
-| Type                                                                                                      | Default |
-| --------------------------------------------------------------------------------------------------------- | ------- |
-| `(address: string, opts?: { onSuccess?: () => void; onError?: (error: Error) => void }) => Promise<void>` |         |
-
-```tsx
-import { useWallet } from "@suiet/wallet-kit";
-
-function YourComponent() {
-  const wallet = useWallet();
-
-  async function handleSwitchAccount() {
-    if (!wallet.connected) return;
-
-    try {
-      const accounts = await wallet.getAccounts();
-      if (accounts.length > 1) {
-        await wallet.switchAccount(accounts[1], {
-          onSuccess: () => {
-            console.log("Successfully switched to account:", accounts[1]);
-            // Handle successful account switch, e.g., update UI
-          },
-          onError: (error) => {
-            console.error("Failed to switch account:", error);
-            // Handle error, e.g., show error message to user
-          },
-        });
-      }
-    } catch (e) {
-      console.error("Failed to switch account:", e);
-    }
-  }
-
-  return <button onClick={handleSwitchAccount}>Switch Account</button>;
-}
-```
-
-:::caution
-Make sure the address you're switching to is available in the wallet's accounts. You can use `getAccounts()` to get the list of available addresses first.
-:::
-
-:::tip
-The `opts` parameter is optional. You can provide either both callbacks, just one, or none at all depending on your needs.
-:::
 
 ### chains
 
@@ -309,8 +262,8 @@ Current connected chain of wallet.
 
 Might not be synced with the wallet if the wallet doesn't support wallet-standard "change" event.
 
-| Type   | Default                                                                                 |
-| ------ | --------------------------------------------------------------------------------------- |
+| Type   | Default                                                      |
+| ------ | ------------------------------------------------------------ |
 | string | the first value of configured [chains](./#chains) or [UnknownChain](/docs/Types/#Chain) |
 
 ### adapter
@@ -319,8 +272,8 @@ The adapter normalized from the raw adapter of the connected wallet. You can cal
 it, which is followed
 the [@mysten/wallet-standard](https://github.com/MystenLabs/sui/tree/main/sdk/wallet-adapter/wallet-standard)
 
-| Type                                         | Default   |
-| -------------------------------------------- | --------- | --------- |
+| Type                             | Default   |
+|----------------------------------| --------- |
 | [IWalletAdapter](/docs/Types#IWalletAdapter) | undefined | undefined |
 
 ### signTransaction
@@ -328,8 +281,9 @@ the [@mysten/wallet-standard](https://github.com/MystenLabs/sui/tree/main/sdk/wa
 The function is for transaction signing.
 
 | Type                                                         | Default |
-| ------------------------------------------------------------ | ------- |
+|--------------------------------------------------------------| ------- |
 | `({transaction: Transaction}) => Promise<SignedTransaction>` |         |
+
 
 ### signAndExecuteTransaction
 
@@ -339,13 +293,13 @@ With this new feature, you can use the `signAndExecuteTransaction` method to sig
 
 This is an enhanced API of `signAndExecuteTransactionBlock` where the comparison between the two APIs are shown in the table.
 
-|              API               | Execution | FullNode for Execution |               GraphQL API support               |
-| :----------------------------: | :-------: | :--------------------: | :---------------------------------------------: |
-| signAndExecuteTransactionBlock | on Wallet |  Specified by Wallet   |        Depend on wallet's implementation        |
-|   signAndExecuteTransaction    |  on DApp  |   Specified by DApp    | Can be done by customizing the execute function |
+| API |     Execution     | FullNode for Execution |                   GraphQL API support                   | 
+|:-:|:-----------------:| :-: |:-------------------------------------------------------:|
+| signAndExecuteTransactionBlock |   on Wallet | Specified by Wallet |            Depend on wallet's implementation            |
+| signAndExecuteTransaction | on DApp | Specified by DApp |     Can be done by customizing the execute function     |           
 
 | Type                                                                                                                                                                                    | Default |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- |
 | `({transactionBlock: TransactionBlock, requestType?: ExecuteTransactionRequestType, options?: SuiTransactionBlockResponseOptions}) => Promise<SuiSignAndExecuteTransactionBlockOutput>` |         |
 
 ### signPersonalMessage
@@ -353,7 +307,7 @@ This is an enhanced API of `signAndExecuteTransactionBlock` where the comparison
 The function is for personal message signing. The return strings are in base64 format.
 
 | Type                                                                            | Default |
-| ------------------------------------------------------------------------------- | ------- |
+|---------------------------------------------------------------------------------| ------- |
 | `(input: {message: Uint8Array}) => Promise<{signature: string; bytes: string}>` |         |
 
 ### verifySignedPersonalMessage
@@ -384,16 +338,16 @@ It supports signatures of multiple schemes, such as  ed25519, secp256k1, secp256
 
 The function for wallet event listening. Returns the off function to remove listener.
 
-| Type                                                                                    | Default |
-| --------------------------------------------------------------------------------------- | ------- |
+| Type                                                         | Default |
+| ------------------------------------------------------------ | ------- |
 | `<E extends WalletEvent>(event: E, listener: WalletEventListeners[E], ) => () => void;` |         |
 
 All the wallet events:
 
-| Event         | Listener                                                                               | Description                                               |
-| ------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| accountChange | `(params: { account: WalletAccount; }) => void;`                                       | Emit when wallet app changes its account                  |
-| featureChange | `(params: { features: string[]; }) => void;`                                           | Emit when wallet app changes its wallet-standard features |
+| Event         | Listener                                                     | Description                                               |
+| ------------- | ------------------------------------------------------------ | --------------------------------------------------------- |
+| accountChange | `(params: { account: WalletAccount; }) => void;`             | Emit when wallet app changes its account                  |
+| featureChange | `(params: { features: string[]; }) => void;`                 | Emit when wallet app changes its wallet-standard features |
 | change        | `(params: { chain?: string, account?: WalletAccount; features?: string[]; }) => void;` | Raw change event defined by wallet-standard               |
 
 ## Deprecated API
@@ -405,7 +359,7 @@ Deprecated, use [signAndExecuteTransaction](#signandexecutetransaction) instead.
 The universal function to send and execute transactions via connected wallet.
 
 | Type                                                                                                                                                                               | Default |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- |
 | `({transactionBlock: Transaction, requestType?: ExecuteTransactionRequestType, options?: SuiTransactionBlockResponseOptions}) => Promise<SuiSignAndExecuteTransactionBlockOutput>` |         |
 
 ### signTransactionBlock
@@ -414,8 +368,8 @@ Deprecated, use [signTransaction](#signtransaction) instead.
 
 The function is for transaction signing.
 
-| Type                                                                          | Default |
-| ----------------------------------------------------------------------------- | ------- |
+| Type                                                              | Default |
+|-------------------------------------------------------------------| ------- |
 | `({transactionBlock: Transaction}) => Promise<SuiSignTransactionBlockOutput>` |         |
 
 ### executeMoveCall and executeSerializedMoveCall
@@ -447,7 +401,7 @@ const wallet = useWallet();
 Deprecated, use [signPersonalMessage](#signpersonalmessage) instead.
 
 | Type                                                                                   | Default |
-| -------------------------------------------------------------------------------------- | ------- |
+|----------------------------------------------------------------------------------------| ------- |
 | `(input: {message: Uint8Array}) => Promise<{signature: string; messageBytes: string}>` |         |
 
 

--- a/website/docs/tutorial/hooks-only.md
+++ b/website/docs/tutorial/hooks-only.md
@@ -78,4 +78,49 @@ function WalletSelector() {
 }
 ```
 
-T
+### Switch between accounts
+
+Once connected, users may want to switch between different accounts in their wallet. You can use `switchAccount` method to achieve this:
+
+```jsx
+import { useWallet } from '@suiet/wallet-kit';
+
+function AccountSwitcher() {
+  const wallet = useWallet();
+
+  async function handleSwitchAccount(address) {
+    if (!wallet.connected) return
+    try {
+      const newAccount = await wallet.switchAccount(address);
+      console.log('Successfully switched to account:', newAccount);
+    } catch (e) {
+      console.error('Failed to switch account:', e);
+    }
+  }
+
+  const renderWalletAccounts = () => {
+    if (!wallet.connected) return null;
+    const accounts = wallet.getAccounts();
+    if (!accounts?.length) return null;
+    return <ol>
+      {accounts.map((account) => {
+        return <li key={account.address} onClick={() => handleSwitchAccount(account.address)}
+          style={{ cursor: "pointer" }}
+        >
+          <p>address: {account.address}</p>
+          <p>publicKey: {account.publicKey ?? "not supported"}</p>
+        </li>
+      })}
+    </ol>;
+  }
+
+  return (
+    <div>
+      <h3>Your Accounts</h3>
+      {renderWalletAccounts()}
+    </div>
+  );
+}
+```
+
+


### PR DESCRIPTION
- Add a new switchAccount API which allows dapps to select an account from the permitted account list that wallet provides. (Available in Hook-only mode, no default UI with it now)
- Update docs about the new switchAccount API